### PR TITLE
[Bugfix] Set content for GET requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-signed-requests",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/payload.ts
+++ b/src/payload.ts
@@ -22,6 +22,10 @@ export default class Payload {
       return JSON.stringify(this.content);
     }
 
+    if (this.content === undefined) {
+      return "";
+    }
+
     return this.content;
   }
 }

--- a/test/payload-test.ts
+++ b/test/payload-test.ts
@@ -94,5 +94,13 @@ describe("Payload", () => {
 
       assert.strictEqual(payload.toString(), expected);
     });
+
+    it("stringifies a json payload when there is no content", () => {
+      const payload = new Payload(id, method, timestamp, uri, undefined);
+      // tslint:disable-next-line:max-line-length
+      const expected = String.raw`{"id":"303103f5-3dca-4704-96ad-860717769ec9","method":"GET","timestamp":"2018-04-06 20:34:47","uri":"https://localhost","content":""}`;
+
+      assert.strictEqual(payload.toString(), expected);
+    });
   });
 });


### PR DESCRIPTION
Fixes a bug where content is not set on GET requests causing the signature to be invalid